### PR TITLE
add HTTP access controle with flask_corps

### DIFF
--- a/api/v1/app.py
+++ b/api/v1/app.py
@@ -1,12 +1,14 @@
 #!/usr/bin/python3
 """This module starts a Flask web application"""
 from flask import Flask, jsonify
+from flask_cors import CORS
 from models import storage
 from api.v1.views import app_views
 from os import getenv
 
 app = Flask(__name__)
 app.register_blueprint(app_views)
+cors = CORS(app, ressources={r"/api/v1/*": {"origins": "0.0.0.0"}})
 
 host = getenv('HBNB_API_HOST', '0.0.0.0')
 port = getenv('HBNB_API_PORT', '5000')


### PR DESCRIPTION
Hi Rémi, for the task 13, we have to add an HTTP access control. 
I invite you to install flask_corps with this command : pip3 install flask_cors
When you execute this command "curl -X GET http://0.0.0.0:5000/api/v1/cities/b44aab67-581e-4a31-9662-14e497bfb727 -vvv" you can see this header : < Access-Control-Allow-Origin: *

